### PR TITLE
Reduce length of parameter and variable names to pass validation by XPP 8.0

### DIFF
--- a/SkM_AP_KCa.ode
+++ b/SkM_AP_KCa.ode
@@ -17,11 +17,11 @@ Parm gNa_max=0.9, gcabar=0.05, gK_max=0.415, gL_max=0.0024, gKca=0.5
 Parm ENa=50.0, EK=-70.0, EL=-75.0, ECa=50
 Parm En=-40.0, Em=-42.0, Eh=-41.0
 Parm Ct=0.04, Cm=0.0090, Rs=15.0, Am=200.0
-Parm alpha_n_max=0.0229, beta_n_max=0.09616
-Parm v_alpha_m=10.0, v_alpha_n=7.0, v_alpha_h=14.7
-Parm alpha_m_max=0.208, beta_m_max=2.081
+Parm a_n_max=0.0229, b_n_max=0.09616
+Parm v_alph_m=10.0, v_alph_n=7.0, v_alph_h=14.7
+Parm a_m_max=0.208, b_m_max=2.081
 Parm v_beta_n=40.0, v_beta_m=18.0, v_beta_h=7.6
-Parm alpha_h_max=0.0156, beta_h_max=3.382
+Parm a_h_max=0.0156, b_h_max=3.382
 
 Parm kd=0.18, alpha=4.5e-6, kpmca=0.2, pleak=0.0005,  kserca=0.4
 Parm d1=0.84, d2=1.0, k1=0.18, k2=0.011, bbar=0.28, abar=0.48
@@ -31,12 +31,12 @@ Parm fer=0.01, vcytver=5, fcyt=0.01
 Parm period=50, iStim_mag=2, iStim_beg=5, iStim_dur=1
 iStim=  iStim_mag * heav(mod(t,period)-iStim_beg) * heav(iStim_beg+iStim_dur-mod(t,period))
 
-beta_n= (beta_n_max * exp(((En - Vm) / v_beta_n)))
-beta_m= (beta_m_max * exp(((Em - Vm) / v_beta_m)))
-beta_h= (beta_h_max / (1.0 + exp(((Eh - Vm) / v_beta_h))))
-alpha_n= (alpha_n_max * (Vm - En) / (1.0 - exp(((En - Vm) / v_alpha_n))))
-alpha_m= (alpha_m_max * (Vm - Em) / (1.0 - exp(((Em - Vm) / v_alpha_m))))
-alpha_h= (alpha_h_max * exp(((Eh - Vm) / v_alpha_h)))
+beta_n= (b_n_max * exp(((En - Vm) / v_beta_n)))
+beta_m= (b_m_max * exp(((Em - Vm) / v_beta_m)))
+beta_h= (b_h_max / (1.0 + exp(((Eh - Vm) / v_beta_h))))
+alpha_n= (a_n_max * (Vm - En) / (1.0 - exp(((En - Vm) / v_alph_n))))
+alpha_m= (a_m_max * (Vm - Em) / (1.0 - exp(((Em - Vm) / v_alph_m))))
+alpha_h= (a_h_max * exp(((Eh - Vm) / v_alph_h)))
 
 % IK(Ca) PARAMETERS
 alp(Vm) = abar/(1+k1*exp(-2*d1*96.485*Vm/8.313424/(310))/c)


### PR DESCRIPTION
- Replaced `alpha_` prefix parameter names with `a_`
- Replaced `beta_` prefix for parameter names with `b_`